### PR TITLE
Fix permission note rendering

### DIFF
--- a/src/components/admin/RoleManagement.jsx
+++ b/src/components/admin/RoleManagement.jsx
@@ -290,8 +290,7 @@ const RoleManagement = ({ currentUser }) => {
         {editingPermissions && (
           <div className="mt-4 bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg text-sm text-blue-700 dark:text-blue-300">
             <p>
-              <strong>Note:</strong> Changing permissions affects system security. Super Admin permissions cannot be modified.
-              {roleKey !== 'super_admin' && " Click on the checkmarks to toggle permissions for each role."}
+              <strong>Note:</strong> Changing permissions affects system security. Super Admin permissions cannot be modified. Click on the checkmarks to toggle permissions for each role.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary
- fix note about toggling role permissions so it always shows

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6885b6708d30832cabc6f0eaba28c660